### PR TITLE
Make selected evidence fields available at the issue level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ v4.12.0 (XXXX 2024)
   - Migrate integration to use Mappings Manager
   - Update Dradis links in README
   - Use cweid as the issue identifier
+  - Make `issueid`, `line`, `module`, `sourcefile`, & `sourcefilepath` available at the issue and evidence level
 
 v4.11.0 (January 2024)
   - No changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ v4.12.0 (XXXX 2024)
   - Migrate integration to use Mappings Manager
   - Update Dradis links in README
   - Use cweid as the issue identifier
-  - Make `issueid`, `line`, `module`, `sourcefile`, & `sourcefilepath` available at the issue and evidence level
+  - Add `issueid`, `line`, `module`, `sourcefile`, & `sourcefilepath` as available issue fields
 
 v4.11.0 (January 2024)
   - No changes

--- a/lib/dradis/plugins/veracode/mapping.rb
+++ b/lib/dradis/plugins/veracode/mapping.rb
@@ -42,12 +42,17 @@ module Dradis::Plugins::Veracode
         'issue.cwename',
         'issue.description',
         'issue.exploitlevel',
+        'issue.issueid',
+        'issue.line',
         'issue.mitigation_status',
         'issue.mitigation_status_desc',
+        'issue.module',
         'issue.note',
         'issue.remediation_status',
         'issue.remediationeffort',
-        'issue.severity'
+        'issue.severity',
+        'issue.sourcefile',
+        'issue.sourcefilepath'
       ]
     }.freeze
   end

--- a/lib/veracode/flaw.rb
+++ b/lib/veracode/flaw.rb
@@ -20,8 +20,9 @@ module Veracode
       [
         # attributes
         :categoryid, :categoryname, :cweid, :cwename, :description, :exploitlevel,
-        :mitigation_status, :mitigation_status_desc, :note, :remediation_status,
-        :remediationeffort, :severity
+        :issueid, :line, :mitigation_status, :mitigation_status_desc, :module, 
+        :note, :remediation_status, :remediationeffort, :severity, :sourcefile, 
+        :sourcefilepath
       ]
     end
 


### PR DESCRIPTION
### Summary
Make the following evidence fields available at the issue level: 
```
issueid
line
module
sourcefile
sourcefilepath
```

### Testing Steps
Use syntax like `{{ veracode[issue.issueid] }}` in the mappings manager and confirm that the preview appears as expected

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs
