### PR TITLE
Importer/sca

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.13.0 (Month 2024)
+  - Import data from the software composition analysis section
+
 v4.12.0 (May 2024)
   - Create evidence for every instance of <flaw>
   - Update Dradis links in README

--- a/lib/dradis-veracode.rb
+++ b/lib/dradis-veracode.rb
@@ -7,3 +7,4 @@ require 'dradis/plugins/veracode'
 # Load supporting Veracode classes
 require 'veracode/evidence'
 require 'veracode/flaw'
+require 'veracode/vulnerability'

--- a/lib/dradis/plugins/veracode.rb
+++ b/lib/dradis/plugins/veracode.rb
@@ -7,7 +7,7 @@ end
 
 require 'dradis/plugins/veracode/engine'
 require 'dradis/plugins/veracode/field_processor'
-require 'dradis/plugins/veracode/formats/component'
+require 'dradis/plugins/veracode/formats/vulnerability'
 require 'dradis/plugins/veracode/formats/flaw'
 require 'dradis/plugins/veracode/mapping'
 require 'dradis/plugins/veracode/importer'

--- a/lib/dradis/plugins/veracode.rb
+++ b/lib/dradis/plugins/veracode.rb
@@ -7,6 +7,8 @@ end
 
 require 'dradis/plugins/veracode/engine'
 require 'dradis/plugins/veracode/field_processor'
+require 'dradis/plugins/veracode/formats/component'
+require 'dradis/plugins/veracode/formats/flaw'
 require 'dradis/plugins/veracode/mapping'
 require 'dradis/plugins/veracode/importer'
 require 'dradis/plugins/veracode/version'

--- a/lib/dradis/plugins/veracode/field_processor.rb
+++ b/lib/dradis/plugins/veracode/field_processor.rb
@@ -4,15 +4,14 @@ module Dradis
       class FieldProcessor < Dradis::Plugins::Upload::FieldProcessor
         def post_initialize(args = {})
           @record =
-            case data
-            when ::Veracode::Flaw, ::Veracode::Evidence, ::Veracode::Vulnerability
+            if data.is_a?(::Veracode::Flaw) || data.is_a?(::Veracode::Evidence) || data.is_a?(::Veracode::Vulnerability)
               data
             # Note: The evidence and flaw samples are the same but they need to
             # be differentiated in the plugins manager preview. In that case,
             # we're adding a "dradis_type" attribute in the evidence.sample file
-            when (data['dradis_type'] == 'evidence')
+            elsif data['dradis_type'] == 'evidence'
               ::Veracode::Evidence.new(data.at_xpath('./staticflaws/flaw'))
-            when (data.name == 'component')
+            elsif data.name == 'component'
               ::Veracode::Vulnerability.new(data.at_xpath('.//vulnerability'))
             else
               ::Veracode::Flaw.new(data.at_xpath('./staticflaws/flaw'))

--- a/lib/dradis/plugins/veracode/field_processor.rb
+++ b/lib/dradis/plugins/veracode/field_processor.rb
@@ -4,7 +4,7 @@ module Dradis
       class FieldProcessor < Dradis::Plugins::Upload::FieldProcessor
         def post_initialize(args = {})
           @record =
-            if (data.is_a?(::Veracode::Flaw) || data.is_a?(::Veracode::Evidence))
+            if (data.is_a?(::Veracode::Flaw) || data.is_a?(::Veracode::Evidence) || data.is_a?(::Veracode::Vulnerability))
               data
 
             # Note: The evidence and flaw samples are the same but they need to
@@ -12,6 +12,8 @@ module Dradis
             # we're adding a "dradis_type" attribute in the evidence.sample file
             elsif (data['dradis_type'] == 'evidence')
               ::Veracode::Evidence.new(data.at_xpath('./staticflaws/flaw'))
+            elsif (data.name == 'component')
+              ::Veracode::Vulnerability.new(data.at_xpath('.//vulnerability'))
             else
               ::Veracode::Flaw.new(data.at_xpath('./staticflaws/flaw'))
             end

--- a/lib/dradis/plugins/veracode/field_processor.rb
+++ b/lib/dradis/plugins/veracode/field_processor.rb
@@ -12,7 +12,7 @@ module Dradis
             elsif data['dradis_type'] == 'evidence'
               ::Veracode::Evidence.new(data.at_xpath('./staticflaws/flaw'))
             elsif data.name == 'component'
-              ::Veracode::Vulnerability.new(data.at_xpath('.//vulnerability'))
+              ::Veracode::Vulnerability.new(data.at_xpath('./vulnerabilities/vulnerability'))
             else
               ::Veracode::Flaw.new(data.at_xpath('./staticflaws/flaw'))
             end

--- a/lib/dradis/plugins/veracode/field_processor.rb
+++ b/lib/dradis/plugins/veracode/field_processor.rb
@@ -4,15 +4,15 @@ module Dradis
       class FieldProcessor < Dradis::Plugins::Upload::FieldProcessor
         def post_initialize(args = {})
           @record =
-            if (data.is_a?(::Veracode::Flaw) || data.is_a?(::Veracode::Evidence) || data.is_a?(::Veracode::Vulnerability))
+            case data
+            when ::Veracode::Flaw, ::Veracode::Evidence, ::Veracode::Vulnerability
               data
-
             # Note: The evidence and flaw samples are the same but they need to
             # be differentiated in the plugins manager preview. In that case,
             # we're adding a "dradis_type" attribute in the evidence.sample file
-            elsif (data['dradis_type'] == 'evidence')
+            when (data['dradis_type'] == 'evidence')
               ::Veracode::Evidence.new(data.at_xpath('./staticflaws/flaw'))
-            elsif (data.name == 'component')
+            when (data.name == 'component')
               ::Veracode::Vulnerability.new(data.at_xpath('.//vulnerability'))
             else
               ::Veracode::Flaw.new(data.at_xpath('./staticflaws/flaw'))

--- a/lib/dradis/plugins/veracode/formats/component.rb
+++ b/lib/dradis/plugins/veracode/formats/component.rb
@@ -1,0 +1,23 @@
+module Dradis::Plugins::Veracode::Formats
+  module Component
+
+    private
+
+    def parse_component(xml_component)
+      xml_component.xpath('.//xmlns:vulnerability').each do |xml_vuln|
+        parse_vulnerability(xml_vuln)
+      end
+    end
+
+    def parse_vulnerability(xml_vuln)
+      cve_id = xml_vuln[:cve_id]
+      vuln = ::Veracode::Vulnerability.new(xml_vuln)
+      issue_text = mapping_service.apply_mapping(source: 'issue', data: vuln)
+      issue = content_service.create_issue(text: issue_text, id: cve_id)
+
+      evidence = ::Veracode::Vulnerability.new(xml_vuln)
+      evidence_text = mapping_service.apply_mapping(source: 'evidence', data: evidence)
+      content_service.create_evidence(content: evidence_text, issue: issue, node: node)
+    end
+  end
+end

--- a/lib/dradis/plugins/veracode/formats/flaw.rb
+++ b/lib/dradis/plugins/veracode/formats/flaw.rb
@@ -1,0 +1,19 @@
+module Dradis::Plugins::Veracode::Formats
+  module Flaw
+
+    private
+
+    def parse_flaw(xml_flaw)
+      cwe_id = xml_flaw[:cweid]
+      logger.info { "\t\t => Creating issue and evidence (flaw cweid: #{ cwe_id })" }
+
+      flaw = ::Veracode::Flaw.new(xml_flaw)
+      issue_text = mapping_service.apply_mapping(source: 'issue', data: flaw)
+      issue = content_service.create_issue(text: issue_text, id: cwe_id)
+
+      veracode_evidence = ::Veracode::Evidence.new(xml_flaw)
+      evidence_text = mapping_service.apply_mapping(source: 'evidence', data: veracode_evidence)
+      content_service.create_evidence(content: evidence_text, issue: issue, node: node)
+    end
+  end
+end

--- a/lib/dradis/plugins/veracode/formats/flaw.rb
+++ b/lib/dradis/plugins/veracode/formats/flaw.rb
@@ -11,8 +11,8 @@ module Dradis::Plugins::Veracode::Formats
       issue_text = mapping_service.apply_mapping(source: 'issue', data: flaw)
       issue = content_service.create_issue(text: issue_text, id: cwe_id)
 
-      veracode_evidence = ::Veracode::Evidence.new(xml_flaw)
-      evidence_text = mapping_service.apply_mapping(source: 'evidence', data: veracode_evidence)
+      evidence = ::Veracode::Evidence.new(xml_flaw)
+      evidence_text = mapping_service.apply_mapping(source: 'evidence', data: evidence)
       content_service.create_evidence(content: evidence_text, issue: issue, node: node)
     end
   end

--- a/lib/dradis/plugins/veracode/formats/vulnerability.rb
+++ b/lib/dradis/plugins/veracode/formats/vulnerability.rb
@@ -1,22 +1,16 @@
 module Dradis::Plugins::Veracode::Formats
-  module Component
+  module Vulnerability
 
     private
-
-    def parse_component(xml_component)
-      xml_component.xpath('.//xmlns:vulnerability').each do |xml_vuln|
-        parse_vulnerability(xml_vuln)
-      end
-    end
 
     def parse_vulnerability(xml_vuln)
       cve_id = xml_vuln[:cve_id]
       vuln = ::Veracode::Vulnerability.new(xml_vuln)
-      issue_text = mapping_service.apply_mapping(source: 'issue', data: vuln)
+      issue_text = mapping_service.apply_mapping(source: 'sca_issue', data: vuln)
       issue = content_service.create_issue(text: issue_text, id: cve_id)
 
       evidence = ::Veracode::Vulnerability.new(xml_vuln)
-      evidence_text = mapping_service.apply_mapping(source: 'evidence', data: evidence)
+      evidence_text = mapping_service.apply_mapping(source: 'sca_evidence', data: evidence)
       content_service.create_evidence(content: evidence_text, issue: issue, node: node)
     end
   end

--- a/lib/dradis/plugins/veracode/gem_version.rb
+++ b/lib/dradis/plugins/veracode/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 12
+        MINOR = 13
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/veracode/gem_version.rb
+++ b/lib/dradis/plugins/veracode/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 13
+        MINOR = 14
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/veracode/importer.rb
+++ b/lib/dradis/plugins/veracode/importer.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::Veracode
     attr_accessor :node
 
     include Dradis::Plugins::Veracode::Formats::Flaw
-    include Dradis::Plugins::Veracode::Formats::Sca
+    include Dradis::Plugins::Veracode::Formats::Vulnerability
 
     def self.templates
       { evidence: 'evidence', issue: 'issue' }
@@ -40,9 +40,9 @@ module Dradis::Plugins::Veracode
         end
       end
 
-      # parse each software_composition_analysis > vulnerabile_components -> component
-      xml.root.xpath('./xmlns:software_composition_analysis/xmlns:vulnerable_components/xmlns:component').each do |xml_component|
-        parse_component(xml_component)
+      # parse each software_composition_analysis > ... > vulnerability
+      xml.root.xpath('.//xmlns:vulnerability').each do |xml_vuln|
+        parse_vulnerability(xml_vuln)
       end
     end
 

--- a/lib/dradis/plugins/veracode/importer.rb
+++ b/lib/dradis/plugins/veracode/importer.rb
@@ -6,7 +6,7 @@ module Dradis::Plugins::Veracode
     include Dradis::Plugins::Veracode::Formats::Vulnerability
 
     def self.templates
-      { evidence: 'evidence', issue: 'issue' }
+      { evidence: ['evidence', 'sca_evidence'], issue: ['issue', 'sca_issue'] }
     end
 
     # The framework will call this function if the user selects this plugin from

--- a/lib/dradis/plugins/veracode/importer.rb
+++ b/lib/dradis/plugins/veracode/importer.rb
@@ -32,16 +32,18 @@ module Dradis::Plugins::Veracode
       # create app_name, and parse attributes
       @node = parse_report_details(xml.root)
 
-      # parse each severity > category > cwe > flaws
-      xml.root.xpath('./xmlns:severity').each do |xml_severity|
+      # parse each severity > category > cwe > staticflaws > flaw
+      xml.root.xpath('xmlns:severity').each do |xml_severity|
         logger.info { "\t => Severity (level: #{ xml_severity[:level] })" }
-        xml_severity.xpath('.//xmlns:flaw').each do |xml_flaw|
+        xml_severity.xpath('./xmlns:category/xmlns:cwe/xmlns:staticflaws/xmlns:flaw').each do |xml_flaw|
           parse_flaw(xml_flaw)
         end
       end
 
       # parse each software_composition_analysis > ... > vulnerability
-      xml.root.xpath('.//xmlns:vulnerability').each do |xml_vuln|
+      xml.root.xpath(
+        'xmlns:software_composition_analysis/xmlns:vulnerable_components//xmlns:vulnerability'
+      ).each do |xml_vuln|
         parse_vulnerability(xml_vuln)
       end
     end

--- a/lib/dradis/plugins/veracode/mapping.rb
+++ b/lib/dradis/plugins/veracode/mapping.rb
@@ -22,14 +22,14 @@ module Dradis::Plugins::Veracode
       sca_evidence: {
         'File' => "{{ vercaode[sca_evidence.file_name] }}\n{{ vercaode[sca_evidence.file_path_value] }}",
         'Library' => "{{ vercaode[sca_evidence.library] }}\n{{ vercaode[sca_evidence.library_id] }}",
-        'Mitigation' => "{{ vercaode[sca_evidence.mitigation_action] }}\n{{ vercaode[sca_evidence.mitigation_description] }}\n{{ vercaode[sca_evidence.mitigation_date] }}"
+        'Mitigation' => "{{ vercaode[sca_evidence.mitigation] }}"
       },
       sca_issue: {
         'Title' => '{{ vercaode[sca_issue.cve_id] }}',
         'Description' => '{{ vercaode[sca_issue.cve_summary] }}',
         'Severity' => '{{ vercaode[sca_issue.severity_desc] }}',
         'Notes' => "CWE: {{ veracode[sca_issue.cwe_id] }}\nCVSS: {{ veracode[sca_issue.cvss_score] }}\nAffects policy compliance: {{ vercaode[sca_issue.vulnerability_affects_policy_compliance] }}",
-        'Mitigation' => "{{ vercaode[sca_issue.mitigation_action] }}\n{{ vercaode[sca_issue.mitigation_description] }}\n{{ vercaode[sca_issue.mitigation_date] }}"
+        'Mitigation' => "{{ vercaode[sca_issue.mitigation] }}"
       }
     }.freeze
 
@@ -66,19 +66,15 @@ module Dradis::Plugins::Veracode
         'sca_evidence.file_path_value',
         'sca_evidence.library',
         'sca_evidence.library_id',
-        'sca_evidence.mitigation_action',
-        'sca_evidence.mitigation_description',
-        'sca_evidence.mitigation_date'
+        'sca_evidence.mitigation',
       ],
-      sca_issues: [
+      sca_issue: [
         'sca_issue.cve_id',
         'sca_issue.severity_desc',
         'sca_issue.cwe_id',
         'sca_issue.cve_summary',
-        'sca_issue.mitigation_action',
-        'sca_issue.mitigation_description',
-        'sca_issue.mitigation_date',
         'sca_issue.cvss_score',
+        'sca_issue.mitigation',
         'sca_issue.severity',
         'sca_issue.vulnerability_affects_policy_compliance'
       ],

--- a/lib/dradis/plugins/veracode/mapping.rb
+++ b/lib/dradis/plugins/veracode/mapping.rb
@@ -18,6 +18,18 @@ module Dradis::Plugins::Veracode
         'Category' => '{{ veracode[issue.categoryname] }}',
         'CWE' => '{{ veracode[issue.cweid] }}',
         'RemediationStatus' => '{{ veracode[issue.remediation_status] }}'
+      },
+      sca_evidence: {
+        'File' => "{{ vercaode[sca_evidence.file_name] }}\n{{ vercaode[sca_evidence.file_path_value] }}",
+        'Library' => "{{ vercaode[sca_evidence.library] }}\n{{ vercaode[sca_evidence.library_id] }}",
+        'Mitigation' => "{{ vercaode[sca_evidence.mitigation_action] }}\n{{ vercaode[sca_evidence.mitigation_description] }}\n{{ vercaode[sca_evidence.mitigation_date] }}"
+      },
+      sca_issue: {
+        'Title' => '{{ vercaode[sca_issue.cve_id] }}',
+        'Description' => '{{ vercaode[sca_issue.cve_summary] }}',
+        'Severity' => '{{ vercaode[sca_issue.severity_desc] }}',
+        'Notes' => "CWE: {{ veracode[sca_issue.cwe_id] }}\nCVSS: {{ veracode[sca_issue.cvss_score] }}\nAffects policy compliance: {{ vercaode[sca_issue.vulnerability_affects_policy_compliance] }}",
+        'Mitigation' => "{{ vercaode[sca_issue.mitigation_action] }}\n{{ vercaode[sca_issue.mitigation_description] }}\n{{ vercaode[sca_issue.mitigation_date] }}"
       }
     }.freeze
 
@@ -48,7 +60,28 @@ module Dradis::Plugins::Veracode
         'issue.remediation_status',
         'issue.remediationeffort',
         'issue.severity'
-      ]
+      ],
+      sca_evidence: [
+        'sca_evidence.file_name',
+        'sca_evidence.file_path_value',
+        'sca_evidence.library',
+        'sca_evidence.library_id',
+        'sca_evidence.mitigation_action',
+        'sca_evidence.mitigation_description',
+        'sca_evidence.mitigation_date'
+      ],
+      sca_issues: [
+        'sca_issue.cve_id',
+        'sca_issue.severity_desc',
+        'sca_issue.cwe_id',
+        'sca_issue.cve_summary',
+        'sca_issue.mitigation_action',
+        'sca_issue.mitigation_description',
+        'sca_issue.mitigation_date',
+        'sca_issue.cvss_score',
+        'sca_issue.severity',
+        'sca_issue.vulnerability_affects_policy_compliance'
+      ],
     }.freeze
   end
 end

--- a/lib/dradis/plugins/veracode/mapping.rb
+++ b/lib/dradis/plugins/veracode/mapping.rb
@@ -20,16 +20,16 @@ module Dradis::Plugins::Veracode
         'RemediationStatus' => '{{ veracode[issue.remediation_status] }}'
       },
       sca_evidence: {
-        'File' => "{{ vercaode[sca_evidence.file_name] }}\n{{ vercaode[sca_evidence.file_path_value] }}",
-        'Library' => "{{ vercaode[sca_evidence.library] }}\n{{ vercaode[sca_evidence.library_id] }}",
-        'Mitigation' => "{{ vercaode[sca_evidence.mitigation] }}"
+        'File' => "{{ veracode[sca_evidence.file_name] }}\n{{ veracode[sca_evidence.file_path_value] }}",
+        'Library' => "{{ veracode[sca_evidence.library] }}\n{{ veracode[sca_evidence.library_id] }}",
+        'Mitigation' => "{{ veracode[sca_evidence.mitigation] }}"
       },
       sca_issue: {
-        'Title' => '{{ vercaode[sca_issue.cve_id] }}',
-        'Description' => '{{ vercaode[sca_issue.cve_summary] }}',
-        'Severity' => '{{ vercaode[sca_issue.severity_desc] }}',
-        'Notes' => "CWE: {{ veracode[sca_issue.cwe_id] }}\nCVSS: {{ veracode[sca_issue.cvss_score] }}\nAffects policy compliance: {{ vercaode[sca_issue.vulnerability_affects_policy_compliance] }}",
-        'Mitigation' => "{{ vercaode[sca_issue.mitigation] }}"
+        'Title' => '{{ veracode[sca_issue.cve_id] }}',
+        'Description' => '{{ veracode[sca_issue.cve_summary] }}',
+        'Severity' => '{{ veracode[sca_issue.severity_desc] }}',
+        'Notes' => "CWE: {{ veracode[sca_issue.cwe_id] }}\nCVSS: {{ veracode[sca_issue.cvss_score] }}\nAffects policy compliance: {{ veracode[sca_issue.vulnerability_affects_policy_compliance] }}",
+        'Mitigation' => "{{ veracode[sca_issue.mitigation] }}"
       }
     }.freeze
 
@@ -70,12 +70,12 @@ module Dradis::Plugins::Veracode
       ],
       sca_issue: [
         'sca_issue.cve_id',
-        'sca_issue.severity_desc',
-        'sca_issue.cwe_id',
         'sca_issue.cve_summary',
         'sca_issue.cvss_score',
+        'sca_issue.cwe_id',
         'sca_issue.mitigation',
         'sca_issue.severity',
+        'sca_issue.severity_desc',
         'sca_issue.vulnerability_affects_policy_compliance'
       ],
     }.freeze

--- a/lib/veracode/vulnerability.rb
+++ b/lib/veracode/vulnerability.rb
@@ -1,0 +1,51 @@
+module Veracode
+  class Vulnerability
+    attr_reader :xml_vulnerability
+
+    def initialize(xml_vulnerability)
+      @xml_vulnerability = xml_vulnerability
+    end
+
+    # List of supported tags. They can be attributes, simple descendans or
+    # collections (e.g. <references/>, <tags/>)
+    def supported_tags
+      [
+        :cve_id, :severity_desc, :cwe_id, :cve_summary, :file_name, :file_path,
+        :library, :library_id, :mitigation, :cvss_score, :severity,
+        :vulnerability_affects_policy_compliance
+      ]
+    end
+
+    # This allows external callers (and specs) to check for implemented
+    # properties
+    def respond_to?(method, include_private=false)
+      return true if supported_tags.include?(method.to_sym)
+      super
+    end
+
+    # This method is invoked by Ruby when a method that is not defined in this
+    # instance is called.
+    #
+    # In our case we inspect the @method@ parameter and try to find the
+    # attribute, simple descendent or collection that it maps to in the XML
+    # tree.
+    def method_missing(method, *args)
+      # We could remove this check and return nil for any non-recognized tag.
+      # The problem would be that it would make tricky to debug problems with
+      # typos. For instance: <>.potr would return nil instead of raising an
+      # exception
+      unless supported_tags.include?(method)
+        super
+        return
+      end
+
+      # First we try the attributes
+      method_name = method.to_s
+      return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
+
+      # Next we try the parent <component> attributes
+      component = @xml.parent.parent
+      return component.attributes[method_name].value if component.attributes.key?(method_name)
+    end
+  end
+end

--- a/lib/veracode/vulnerability.rb
+++ b/lib/veracode/vulnerability.rb
@@ -10,15 +10,15 @@ module Veracode
     # collections (e.g. <references/>, <tags/>)
     def supported_tags
       [
-        :cve_id, :severity_desc, :cwe_id, :cve_summary, :file_name, :file_path,
-        :library, :library_id, :mitigation, :cvss_score, :severity,
+        :cve_id, :cve_summary, :cvss_score, :cwe_id, :file_name, :file_path,
+        :library, :library_id, :mitigation, :severity, :severity_desc,
         :vulnerability_affects_policy_compliance
       ]
     end
 
     # This allows external callers (and specs) to check for implemented
     # properties
-    def respond_to?(method, include_private=false)
+    def respond_to?(method, include_private = false)
       return true if supported_tags.include?(method.to_sym)
       super
     end

--- a/lib/veracode/vulnerability.rb
+++ b/lib/veracode/vulnerability.rb
@@ -3,7 +3,7 @@ module Veracode
     attr_reader :xml_vulnerability
 
     def initialize(xml_vulnerability)
-      @xml_vulnerability = xml_vulnerability
+      @xml = xml_vulnerability
     end
 
     # List of supported tags. They can be attributes, simple descendans or
@@ -39,8 +39,15 @@ module Veracode
         return
       end
 
-      # First we try the attributes
       method_name = method.to_s
+
+      if method_name == 'mitigation'
+        return @xml.xpath('.//*:mitigation').map do |mitigation|
+          "#{mitigation.attr('action')}\n#{mitigation.attr('description')}\n#{mitigation.attr('date')}"
+        end.join("\n\n")
+      end
+
+      # First we try the attributes
       return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
 
       # Next we try the parent <component> attributes

--- a/spec/dradis/plugins/veracode/importer_spec.rb
+++ b/spec/dradis/plugins/veracode/importer_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'ostruct'
 
 describe Dradis::Plugins::Veracode::Importer do
-
   before(:each) do
     # Stub template service
     templates_dir = File.expand_path('../../../../../templates', __FILE__)

--- a/templates/sca_evidence.sample
+++ b/templates/sca_evidence.sample
@@ -1,0 +1,19 @@
+<component component_id="hash" file_name="filename.jar" sha1="" vulnerabilities="1" max_cvss_score="5.0" version="0.1.1" library="library" library_id="library_id" vendor="library.org" description="Sample description" added_date="2022-12-12 08&#x3a;19&#x3a;55 UTC" component_affects_policy_compliance="false">
+  <file_paths>
+     <file_path value="file_path"/>
+  </file_paths>
+  <licenses>
+     <license name="License" spdx_id="Apache-2.0" license_url="example.com" risk_rating="2" mitigation="false" license_affects_policy_compliance="false">
+        <mitigations/>
+     </license>
+  </licenses>
+  <vulnerabilities>
+     <vulnerability cve_id="CVE-2022-11111" cvss_score="5.0" severity="3" cwe_id="" first_found_date="2022-12-12 08&#x3a;19&#x3a;55 UTC" cve_summary="CVE Summary" severity_desc="Medium" mitigation="true" mitigation_type="Mitigate by Design" mitigated_date="2022-12-12 16&#x3a;00&#x3a;29 UTC" vulnerability_affects_policy_compliance="false">
+        <mitigations>
+           <mitigation action="Approve Mitigation" description="asda" user="sample_user" date="2022-12-12 16&#x3a;00&#x3a;55 UTC"/>
+           <mitigation action="Mitigate by Design" description="fdsa" user="sample_user" date="2022-12-12 15&#x3a;59&#x3a;55 UTC"/>
+        </mitigations>
+     </vulnerability>
+  </vulnerabilities>
+  <violated_policy_rules/>
+</component>

--- a/templates/sca_issue.sample
+++ b/templates/sca_issue.sample
@@ -1,0 +1,19 @@
+<component component_id="hash" file_name="filename.jar" sha1="" vulnerabilities="1" max_cvss_score="5.0" version="0.1.1" library="library" library_id="library_id" vendor="library.org" description="Sample description" added_date="2022-12-12 08&#x3a;19&#x3a;55 UTC" component_affects_policy_compliance="false">
+  <file_paths>
+     <file_path value="file_path"/>
+  </file_paths>
+  <licenses>
+     <license name="License" spdx_id="Apache-2.0" license_url="example.com" risk_rating="2" mitigation="false" license_affects_policy_compliance="false">
+        <mitigations/>
+     </license>
+  </licenses>
+  <vulnerabilities>
+     <vulnerability cve_id="CVE-2022-11111" cvss_score="5.0" severity="3" cwe_id="" first_found_date="2022-12-12 08&#x3a;19&#x3a;55 UTC" cve_summary="CVE Summary" severity_desc="Medium" mitigation="true" mitigation_type="Mitigate by Design" mitigated_date="2022-12-12 16&#x3a;00&#x3a;29 UTC" vulnerability_affects_policy_compliance="false">
+        <mitigations>
+           <mitigation action="Approve Mitigation" description="asda" user="sample_user" date="2022-12-12 16&#x3a;00&#x3a;55 UTC"/>
+           <mitigation action="Mitigate by Design" description="fdsa" user="sample_user" date="2022-12-12 15&#x3a;59&#x3a;55 UTC"/>
+        </mitigations>
+     </vulnerability>
+  </vulnerabilities>
+  <violated_policy_rules/>
+</component>


### PR DESCRIPTION
### Spec
The current Veracode upload integration does not import findings under the `<software_composition_analysis>` section of the output. Users have requested to have these included in the import

### Proposed solution
Veracode files have a <software_composition_analysis> section that we also need to export as requested by HP.

This task performs the following changes:

- Add .sample file to include software_composition_analysis block
- Add default mappings and issue and evidence source fields to mapping.rb
- In importer.rb, check for the presence of software_composition_analysis/vulnerable_components and if present, process sca findings
- Add model for sca vulnerability and sca evidence
- Pull out [parse_flaw](https://github.com/dradis/dradis-veracode/blob/6d99d438efdcb25442be4df4d83083ca6c055880/lib/dradis/plugins/veracode/importer.rb#L58) method into a formats/flaw.rb file and create a formats/vulnerability.rb file
- Update specs


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs
